### PR TITLE
Fix close PR workflow (was deleting the target branch rather than the PR merge branch)

### DIFF
--- a/.github/workflows/clean_site_s3.yml
+++ b/.github/workflows/clean_site_s3.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   BASE_NAME_BUCKET: corentin-ducatez-resume-bucket
+  PR_REF_NAME: "${{ github.event.pull_request.number }}/merge"
 
 jobs:
   terraform:
@@ -15,9 +16,8 @@ jobs:
       - name: Checkout files
         uses: actions/checkout@v3
       - name: Prepare tfvars file with needed variables
-        # Important to use github.head_ref (base branch) rather than github.ref_name (destination branch)
         run: |
-          raw_bucket_name="${{ env.BASE_NAME_BUCKET }}-${{ github.head_ref }}"
+          raw_bucket_name="${{ env.BASE_NAME_BUCKET }}-${{ env.PR_REF_NAME }}"
           echo "::set-output name=bucket_name::${raw_bucket_name////-}"
           echo "aws_credential = {
               AWS_ACCESS_KEY_ID     = \"${{ secrets.AWS_ACCESS_KEY_ID }}\"


### PR DESCRIPTION
… PR merge branch) (#10)

* Debug issue with branch name for clean_site_s3 workflow

* still debugging

* Better debug

* Still debugging

* Remove debug step

* Prevent multiple workflows triggered when reopening PR

* Revert "Prevent multiple workflows triggered when reopening PR"
=> Synchronize event isn't triggered when reopening, sooooo, it'll stay like this due to no other solution

This reverts commit 3918733f2759c96bba92eaa93a90426b50f97cf4.

* Set the PR branch name manually and remove debug prints

Co-authored-by: Corentin Ducatez <corentin_ducatez@hotmail.fr>